### PR TITLE
Add check-build.sh & doc8 to CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        make-command: [ flake8, pylint]
+        make-command: [ doc8, flake8, pylint, check-build]
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: doc8
+doc8:
+	doc8 README.rst
+
 .PHONY: flake8
 flake8:
 	@flake8 --exclude=.git *.py tcms_django_plugin testapp tests testsite
@@ -6,7 +10,7 @@ flake8:
 pylint:
 	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django -d missing-docstring tcms_django_plugin/ tests/ testapp/ testsite/ manage.py
 
-.PHONY: build
-build:
+.PHONY: check-build
+check-build:
 	./tests/check-build.sh
 


### PR DESCRIPTION
Resolves #41 Add check-build.sh & doc8 to CI 

- Add check-build and doc8 into the Makefile and hook them into the GH CI